### PR TITLE
[PATCH 6/6] GenericSource: reset mDecryptHandle when mDataSource is

### DIFF
--- a/media/libmediaplayerservice/nuplayer/GenericSource.cpp
+++ b/media/libmediaplayerservice/nuplayer/GenericSource.cpp
@@ -503,6 +503,7 @@ void NuPlayer::GenericSource::notifyPreparedAndCleanup(status_t err) {
             {
                 Mutex::Autolock _l(mDisconnectLock);
                 mDataSource.clear();
+                mDecryptHandle = NULL;
                 mDrmManagerClient = NULL;
                 mCachedSource.clear();
                 mHttpSource.clear();


### PR DESCRIPTION
 cleared.

Bug: 25070434
Ticket: CYNGNOS-1522

Change-Id: Ib0eb6a419683a0e686a4f63b82e9300cb1f69484
(cherry picked from commit cdc9cf656a8e43875234cb021fffeb4792d7c74e)
(cherry picked from commit 09c291c838bc74bb7c10c22f7232abb946cad8ff)
(cherry picked from commit 4a1edbafe9e1217c407044213c38794cc9ec55b9)
(cherry picked from commit d0b7b37055ed16cf339aa94dbb050d880960a53d)